### PR TITLE
fix: no perms silent error

### DIFF
--- a/packages/bot/src/struct/CommandHandler.ts
+++ b/packages/bot/src/struct/CommandHandler.ts
@@ -114,7 +114,13 @@ export class CommandHandler {
 			)}`;
 
 			// Try to display something to the user.
-			await interaction.followUp({ content, ephemeral: true });
+			if (interaction.replied) {
+				await interaction.followUp({ content, ephemeral: true });
+				return;
+			}
+
+			await interaction.reply({ content, ephemeral: true }).catch(() => null);
+			await interaction.editReply({ content }).catch(() => null);
 		}
 	}
 


### PR DESCRIPTION
Fix no sufficient permissions silent error by replacing the `editReply` and `reply` methods with a ephemeral `followUp`.